### PR TITLE
Oauth scopes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,9 @@ CANVAS_OAUTH_CLIENT_SECRET:
 CANVAS_OAUTH_CANVAS_DOMAIN:
     (required) The domain of your canvas instance (e.g. canvas.instructure.com)
 
+CANVAS_OAUTH_SCOPES:
+    (optional) Specify a list of Canvas API scopes that the access token will provide access to. Canvas API scopes may be found beneath their corresponding endpoints in the "resources" documentation pages. If the developer key does not require scopes and no scopes are specified, the access token will have access to all scopes. Defaults to ``[]``.
+
 CANVAS_OAUTH_TOKEN_EXPIRATION_BUFFER:
     (optional) Specify a ``datetime.timedelta`` that will force a refresh of the access token before it expires according to the ``expires_in`` parameter included in the access token response. Defaults to ``timedelta(0)``.
 

--- a/canvas_oauth/canvas.py
+++ b/canvas_oauth/canvas.py
@@ -20,12 +20,15 @@ def get_oauth_login_url(client_id, redirect_uri, response_type='code',
     """
     authorize_url = AUTHORIZE_URL_PATTERN % settings.CANVAS_OAUTH_CANVAS_DOMAIN
 
+    if scopes and not isinstance(scopes, str):
+        scopes = " ".join(scopes)
+
     auth_request_params = {
         'client_id': client_id,
         'redirect_uri': redirect_uri,
         'response_type': response_type,
         'state': state,
-        'scopes': scopes,
+        'scope': scopes,
         'purpose': purpose,
         'force_login': force_login,
     }

--- a/canvas_oauth/canvas.py
+++ b/canvas_oauth/canvas.py
@@ -19,9 +19,7 @@ def get_oauth_login_url(client_id, redirect_uri, response_type='code',
     """Builds an OAuth request url for Canvas.
     """
     authorize_url = AUTHORIZE_URL_PATTERN % settings.CANVAS_OAUTH_CANVAS_DOMAIN
-
-    if scopes and not isinstance(scopes, str):
-        scopes = " ".join(scopes)
+    scopes = " ".join(scopes) if scopes else None  
 
     auth_request_params = {
         'client_id': client_id,

--- a/canvas_oauth/oauth.py
+++ b/canvas_oauth/oauth.py
@@ -67,7 +67,8 @@ def handle_missing_token(request):
     authorize_url = canvas.get_oauth_login_url(
         settings.CANVAS_OAUTH_CLIENT_ID,
         redirect_uri=oauth_redirect_uri,
-        state=oauth_request_state)
+        state=oauth_request_state,
+        scopes=settings.CANVAS_OAUTH_SCOPES)
 
     logger.info("Redirecting user to %s" % authorize_url)
     return HttpResponseRedirect(authorize_url)

--- a/canvas_oauth/settings.py
+++ b/canvas_oauth/settings.py
@@ -41,3 +41,17 @@ CANVAS_OAUTH_ERROR_TEMPLATE = getattr(
     'CANVAS_OAUTH_ERROR_TEMPLATE',
     'oauth_error.html'
 )
+
+# A list of Canvas API scopes that the access token will provide access to.
+#
+# This is only required if the Canvas API developer key requires scopes
+# (e.g. enforces scopes). Otherwise, the access token will have access to
+# all scopes.
+#
+# Note that Canvas API scopes may be found beneath their corresponding
+# endpoints in the "resources" documentation pages.
+CANVAS_OAUTH_SCOPES = getattr(
+    settings,
+    'CANVAS_OAUTH_SCOPES',
+    []
+)

--- a/canvas_oauth/tests/test_canvas.py
+++ b/canvas_oauth/tests/test_canvas.py
@@ -20,22 +20,23 @@ class TestGetOauthLoginUrl(TestCase):
         auth_qs = urlencode(auth_params)
         return 'https://%s/login/oauth2/auth?%s' % (canvas_domain, auth_qs)
 
-    def test_oauth_login_url_without_scopes(self):
+    def test_oauth_login_url_with_empty_scopes(self):
         auth_params = {
             'response_type': 'code',
             'client_id': settings.CANVAS_OAUTH_CLIENT_ID,
             'redirect_uri': '/oauth/oauth-callback',
             'state': uuid4(),  # random string
         }
-
         expected_url = self._get_expected_url(auth_params)
-        actual_url = get_oauth_login_url(
-            client_id=auth_params['client_id'],
-            redirect_uri=auth_params['redirect_uri'],
-            state=auth_params['state'],
-            scopes=None,
-        )
-        self.assertEqual(expected_url, actual_url)
+
+        for scopes in ([], '', None):
+            actual_url = get_oauth_login_url(
+                client_id=auth_params['client_id'],
+                redirect_uri=auth_params['redirect_uri'],
+                state=auth_params['state'],
+                scopes=scopes,
+            )
+            self.assertEqual(expected_url, actual_url)
 
     def test_oauth_login_url_with_scopes(self):
         scopes = [
@@ -56,7 +57,7 @@ class TestGetOauthLoginUrl(TestCase):
             client_id=auth_params['client_id'],
             redirect_uri=auth_params['redirect_uri'],
             state=auth_params['state'],
-            scopes=auth_params['scope'],
+            scopes=scopes,
         )
         self.assertEqual(expected_url, actual_url)
 

--- a/canvas_oauth/tests/test_canvas.py
+++ b/canvas_oauth/tests/test_canvas.py
@@ -1,33 +1,63 @@
-
-from django.test import TestCase
-from django.conf import settings
-from django.utils import timezone
 from datetime import timedelta
+from operator import itemgetter
 from urllib.parse import urlencode
 from uuid import uuid4
 from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+from django.utils import timezone
 
 from canvas_oauth.exceptions import InvalidOAuthReturnError
 from canvas_oauth.canvas import get_oauth_login_url, get_access_token
 
 
 class TestGetOauthLoginUrl(TestCase):
-    def test_oauth_login_url(self):
+
+    def _get_expected_url(self, auth_params):
         canvas_domain = settings.CANVAS_OAUTH_CANVAS_DOMAIN
+        auth_params = sorted(auth_params.items(), key=itemgetter(0))
+        auth_qs = urlencode(auth_params)
+        return 'https://%s/login/oauth2/auth?%s' % (canvas_domain, auth_qs)
+
+    def test_oauth_login_url_without_scopes(self):
         auth_params = {
             'response_type': 'code',
             'client_id': settings.CANVAS_OAUTH_CLIENT_ID,
             'redirect_uri': '/oauth/oauth-callback',
             'state': uuid4(),  # random string
         }
-        auth_params_sorted = sorted(auth_params.items(), key=lambda val: val[0])
 
-        expected_url = 'https://%s/login/oauth2/auth?%s' % (canvas_domain, urlencode(auth_params_sorted))
+        expected_url = self._get_expected_url(auth_params)
         actual_url = get_oauth_login_url(
             client_id=auth_params['client_id'],
             redirect_uri=auth_params['redirect_uri'],
-            state=auth_params['state'])
+            state=auth_params['state'],
+            scopes=None,
+        )
+        self.assertEqual(expected_url, actual_url)
 
+    def test_oauth_login_url_with_scopes(self):
+        scopes = [
+            'url:GET|/api/v1/courses',
+            'url:GET|/api/v1/courses/:id',
+            'url:GET|/api/v1/courses/:course_id/assignments'
+        ]
+        auth_params = {
+            'response_type': 'code',
+            'client_id': settings.CANVAS_OAUTH_CLIENT_ID,
+            'redirect_uri': '/oauth/oauth-callback',
+            'state': uuid4(),  # random string
+            'scope': " ".join(scopes),
+        }
+
+        expected_url = self._get_expected_url(auth_params)
+        actual_url = get_oauth_login_url(
+            client_id=auth_params['client_id'],
+            redirect_uri=auth_params['redirect_uri'],
+            state=auth_params['state'],
+            scopes=auth_params['scope'],
+        )
         self.assertEqual(expected_url, actual_url)
 
 

--- a/canvas_oauth/tests/test_oauth.py
+++ b/canvas_oauth/tests/test_oauth.py
@@ -181,7 +181,8 @@ class TestHandleMissingToken(TestCase):
         login_url = get_oauth_login_url(
             client_id=settings.CANVAS_OAUTH_CLIENT_ID,
             redirect_uri=redirect_uri,
-            state=request_state)
+            state=request_state,
+            scopes=settings.CANVAS_OAUTH_SCOPES)
 
         # run tests
         response = handle_missing_token(request)

--- a/canvas_oauth/tests/test_settings.py
+++ b/canvas_oauth/tests/test_settings.py
@@ -36,6 +36,7 @@ class TestCanvasOauthSettings(TestCase):
             self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_CANVAS_DOMAIN'))
             self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_TOKEN_EXPIRATION_BUFFER'))
             self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_ERROR_TEMPLATE'))
+            self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_SCOPES'))
 
     def test_optional_oauth_token_expiration_buffer_default_value(self):
         with required_oauth_settings():
@@ -50,3 +51,10 @@ class TestCanvasOauthSettings(TestCase):
             canvas_oauth_settings = importlib.reload(canvas_oauth_settings)
             self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_ERROR_TEMPLATE'))
             self.assertEqual('oauth_error.html', canvas_oauth_settings.CANVAS_OAUTH_ERROR_TEMPLATE)
+
+    def test_optional_oauth_scopes_default_value(self):
+        with required_oauth_settings():
+            canvas_oauth_settings = importlib.import_module(CANVAS_OAUTH_SETTINGS_MODULE_NAME)
+            canvas_oauth_settings = importlib.reload(canvas_oauth_settings)
+            self.assertTrue(hasattr(canvas_oauth_settings, 'CANVAS_OAUTH_SCOPES'))
+            self.assertEqual([], canvas_oauth_settings.CANVAS_OAUTH_SCOPES)


### PR DESCRIPTION
Adds support for [Canvas developer keys](https://canvas.instructure.com/doc/api/file.developer_keys.html) with restricted/enforced scopes.  

When scopes are restricted on the developer key (set by the Canvas administrator),  the third party app must specify the `scope` parameter when requesting an access token. The `scope` should contain a subset of the scopes set for the developer key. 

No changes are required for apps that don't use scopes, since the default assumption is that scopes are not enforced. Apps that do use scopes should specify the list in their settings as demonstrated below.

Example:

```python
CANVAS_OAUTH_SCOPES = [
    'url:GET|/api/v1/courses',
    'url:GET|/api/v1/courses/:id',
    'url:GET|/api/v1/courses/:course_id/assignments'
]
```
